### PR TITLE
fix: filter_var on sandbox/logging booleans

### DIFF
--- a/app/Http/Controllers/InstallmentController.php
+++ b/app/Http/Controllers/InstallmentController.php
@@ -42,7 +42,7 @@ class InstallmentController extends Controller
 
         $this->_head = $this->_controller->prepareHead($head);
 
-        $this->_rb = new RatePAY\RequestBuilder($header['SANDBOX']);
+        $this->_rb = new RatePAY\RequestBuilder(filter_var($header['SANDBOX'], FILTER_VALIDATE_BOOLEAN));
 
         if (!empty($content)) {
             $this->_content = $this->_controller->prepareContent($content);
@@ -60,7 +60,7 @@ class InstallmentController extends Controller
             $this->_rb->setConnectionTimeout($this->_options['retry_delay']);
         }
         if (!empty($header['LOGGING'])) {
-            $this->_controller->setLogging($header['LOGGING']);
+            $this->_controller->setLogging(filter_var($header['LOGGING'], FILTER_VALIDATE_BOOLEAN));
         }
     }
 

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -41,7 +41,7 @@ class PaymentController extends Controller
 
         $this->_head = $head;
         $this->_headArray = $header;
-        $this->_sandbox = $header['SANDBOX'];
+        $this->_sandbox = filter_var($header['SANDBOX'], FILTER_VALIDATE_BOOLEAN);
     }
 
     /**
@@ -79,7 +79,7 @@ class PaymentController extends Controller
 
         $header = $this->_headArray;
         if (!empty($header['LOGGING'])) {
-            $this->_controller->setLogging($header['LOGGING']);
+            $this->_controller->setLogging(filter_var($header['LOGGING'], FILTER_VALIDATE_BOOLEAN));
         }
 
         switch ($this->_options['operation']) {

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -28,12 +28,12 @@ class ProfileController extends Controller
             ]
         ]);
 
-        $rb = new RatePAY\RequestBuilder($header['SANDBOX']);
+        $rb = new RatePAY\RequestBuilder(filter_var($header['SANDBOX'], FILTER_VALIDATE_BOOLEAN));
         $profileRequest = $rb->callProfileRequest($mbHead);
 
         $controller = new BaseController();
         if (!empty($header['LOGGING'])) {
-            $controller->setLogging($header['LOGGING']);
+            $controller->setLogging(filter_var($header['LOGGING'], FILTER_VALIDATE_BOOLEAN));
         }
         return $controller->prepareResponse($profileRequest, 'profile');
     }


### PR DESCRIPTION
Sandbox and Logging take (according to the documentation) a boolean, which would be true/false or True/False.

I faced problems when switching to production, because the ratepay-php-lib does a (bool) cast on the input. If the input is a string - which it is, because it comes from the headers - the cast will always be true. Even if the value of the string would be "false". 

This PR resolves that issue by doing a `filter_var` on the header-values to get them in a clean boolean state before passing them to the lib.